### PR TITLE
Fix: identify browser web apps and Store apps by AppUserModelID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to WindowAnchor will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+- **Installed web apps (PWAs) are no longer treated as plain browser windows** — Web apps installed from Chrome, Brave, Edge or another Chromium browser (e.g. Insilico Terminal, aggr.trade) run inside `chrome.exe`/`brave.exe` and use the same window class as a normal browser window. WindowAnchor identified them only by executable + class name, so restoring a layout opened a fresh browser window instead of the app. Every window's `AppUserModelID` is now captured; web-app windows are matched against the Start-Menu shortcut the browser created on install and relaunched through it. Window matching requires an exact `AppUserModelID` match, so a web-app entry can no longer claim a plain browser window (or vice versa).
+
 ## [1.3.0] - 2026-03-01
 
 ### Added

--- a/src/WindowAnchor/App.xaml.cs
+++ b/src/WindowAnchor/App.xaml.cs
@@ -46,7 +46,10 @@ public partial class App : System.Windows.Application
         var storageService    = new StorageService();
         _storageService       = storageService;
         _monitorService       = new MonitorService();
-        var windowService     = new WindowService();
+        // Settings must exist before WindowService: it reads the dedicated-browser URL patterns
+        // to decide whether address bars are queried during a snapshot.
+        _settingsService      = new SettingsService();
+        var windowService     = new WindowService(_settingsService);
         var jumpListService   = new JumpListService();
         var webAppService     = new WebAppService();
         var workspaceService  = new WorkspaceService(storageService, windowService, _monitorService, jumpListService, webAppService);
@@ -54,8 +57,7 @@ public partial class App : System.Windows.Application
         _workspaceService = workspaceService;
         _coordinator      = new LayoutCoordinator(_monitorService, windowService, workspaceService);
 
-        // Settings + hotkeys
-        _settingsService = new SettingsService();
+        // Hotkeys (settings were created above, before WindowService)
         _hotkeyService   = new HotkeyService();
         _hotkeyService.Initialise();
         ApplyHotkeySettings();
@@ -247,6 +249,19 @@ public partial class App : System.Windows.Application
                 switchItem.Click += (_, _) => OnSwitchWorkspaceClick(captured);
                 workspacesItem.Items.Add(switchItem);
             }
+
+            workspacesItem.Items.Add(new System.Windows.Controls.Separator());
+
+            foreach (var ws in workspaces)
+            {
+                var alignItem = new System.Windows.Controls.MenuItem
+                {
+                    Header = $"Align + minimize others: {ws.Name}"
+                };
+                var captured = ws;
+                alignItem.Click += (_, _) => OnAlignWorkspaceClick(captured);
+                workspacesItem.Items.Add(alignItem);
+            }
         }
 
         // Always append Save + Manage at the bottom
@@ -268,6 +283,11 @@ public partial class App : System.Windows.Application
     private void OnSwitchWorkspaceClick(WindowAnchor.Models.WorkspaceSnapshot snapshot)
     {
         _coordinator?.SwitchWorkspaceAsync(snapshot);
+    }
+
+    private void OnAlignWorkspaceClick(WindowAnchor.Models.WorkspaceSnapshot snapshot)
+    {
+        _coordinator?.AlignAndMinimizeOthersAsync(snapshot);
     }
 
     private void OnExitClick(object sender, RoutedEventArgs e)

--- a/src/WindowAnchor/App.xaml.cs
+++ b/src/WindowAnchor/App.xaml.cs
@@ -48,7 +48,8 @@ public partial class App : System.Windows.Application
         _monitorService       = new MonitorService();
         var windowService     = new WindowService();
         var jumpListService   = new JumpListService();
-        var workspaceService  = new WorkspaceService(storageService, windowService, _monitorService, jumpListService);
+        var webAppService     = new WebAppService();
+        var workspaceService  = new WorkspaceService(storageService, windowService, _monitorService, jumpListService, webAppService);
 
         _workspaceService = workspaceService;
         _coordinator      = new LayoutCoordinator(_monitorService, windowService, workspaceService);

--- a/src/WindowAnchor/Models/AppSettings.cs
+++ b/src/WindowAnchor/Models/AppSettings.cs
@@ -66,4 +66,23 @@ public class AppSettings
     /// User-defined friendly names for monitors, keyed by stable EDID-based MonitorId.
     /// When set, the alias replaces the hardware FriendlyName throughout the UI.
     /// </summary>
-    public Dictionary<string, string>? MonitorAliases { get; set; }}
+    public Dictionary<string, string>? MonitorAliases { get; set; }
+
+    // ── Dedicated browser windows ─────────────────────────────────────────
+    /// <summary>
+    /// URL fragments identifying browser windows that should be restored as their own window
+    /// rather than through the browser's session restore.
+    /// <para>
+    /// Some sites cannot be installed as a web app (no PWA manifest) but are still kept in a
+    /// dedicated window next to a normal multi-tab window. Such a window is indistinguishable
+    /// from any other browser window, so <c>--restore-last-session</c> cannot bring it back
+    /// reliably. When a window's address bar matches one of these fragments, WindowAnchor stores
+    /// the URL and reopens the window with <c>--new-window &lt;url&gt;</c>.
+    /// </para>
+    /// <para>
+    /// A bare domain such as <c>vari.love</c> matches every page on that site. When the list is
+    /// empty no URLs are read at all, so snapshots are unaffected for users not using this.
+    /// </para>
+    /// </summary>
+    public List<string>? DedicatedBrowserUrlPatterns { get; set; }
+}

--- a/src/WindowAnchor/Models/WindowRecord.cs
+++ b/src/WindowAnchor/Models/WindowRecord.cs
@@ -35,6 +35,12 @@ public class WindowRecord
     [JsonIgnore]
     public string DisplayName { get; set; } = "";
 
+    /// <summary>
+    /// Address-bar URL of a browser window, captured only when it matches a configured
+    /// <see cref="AppSettings.DedicatedBrowserUrlPatterns"/> entry. Empty for every other window.
+    /// </summary>
+    public string BrowserUrl { get; set; } = "";
+
     // ── Window state ──────────────────────────────────────────────────────────────
     /// <summary>
     /// <c>WINDOWPLACEMENT.showCmd</c> value (e.g. <c>SW_NORMAL = 1</c>, <c>SW_MAXIMIZE = 3</c>,

--- a/src/WindowAnchor/Models/WindowRecord.cs
+++ b/src/WindowAnchor/Models/WindowRecord.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 namespace WindowAnchor.Models;
 
 /// <summary>
@@ -26,6 +27,13 @@ public class WindowRecord
     /// </para>
     /// </summary>
     public string AppUserModelId { get; set; } = "";
+
+    /// <summary>
+    /// Friendly name for UI display (e.g. "Insilico Terminal" instead of "brave"). Runtime-only,
+    /// filled in for the Save Workspace dialog; never persisted. Falls back to the process name.
+    /// </summary>
+    [JsonIgnore]
+    public string DisplayName { get; set; } = "";
 
     // ── Window state ──────────────────────────────────────────────────────────────
     /// <summary>

--- a/src/WindowAnchor/Models/WindowRecord.cs
+++ b/src/WindowAnchor/Models/WindowRecord.cs
@@ -16,6 +16,17 @@ public class WindowRecord
     /// <summary>First 120 characters of the window title, used for matching and display.</summary>
     public string TitleSnippet   { get; set; } = "";
 
+    /// <summary>
+    /// Explicit <c>AppUserModelID</c> of this window, read via <c>SHGetPropertyStoreForWindow</c>.
+    /// <para>
+    /// Needed in two places: it is the only way to tell an installed web-app window (PWA such as
+    /// Insilico Terminal) apart from a normal browser window, and the only way to relaunch a
+    /// Store/MSIX app with its package identity intact. Classic desktop apps usually have no
+    /// explicit AUMID, so an empty string is the normal case there.
+    /// </para>
+    /// </summary>
+    public string AppUserModelId { get; set; } = "";
+
     // ── Window state ──────────────────────────────────────────────────────────────
     /// <summary>
     /// <c>WINDOWPLACEMENT.showCmd</c> value (e.g. <c>SW_NORMAL = 1</c>, <c>SW_MAXIMIZE = 3</c>,

--- a/src/WindowAnchor/Models/WorkspaceEntry.cs
+++ b/src/WindowAnchor/Models/WorkspaceEntry.cs
@@ -37,6 +37,16 @@ public class WorkspaceEntry
     /// <summary>Command line for <see cref="WebAppLaunchTarget"/>, e.g. <c>--profile-directory=Default --app-id=…</c>.</summary>
     public string? WebAppLaunchArguments { get; set; }
 
+    // ── Dedicated browser window (site kept in its own window) ───────────────
+    /// <summary>
+    /// True when this entry is a browser window that must be reopened as its own window at a
+    /// specific URL, instead of relying on the browser's session restore.
+    /// </summary>
+    public bool    IsDedicatedBrowserWindow { get; set; }
+
+    /// <summary>URL to reopen for a dedicated browser window, e.g. <c>https://vari.love/</c>.</summary>
+    public string  BrowserUrl               { get; set; } = "";
+
     // ── File tracking (null when SavedWithFiles = false) ─────────────────────
     public string? FilePath       { get; set; }
     public int     FileConfidence { get; set; }

--- a/src/WindowAnchor/Models/WorkspaceEntry.cs
+++ b/src/WindowAnchor/Models/WorkspaceEntry.cs
@@ -14,6 +14,29 @@ public class WorkspaceEntry
     public string ProcessName     { get; set; } = "";
     public string WindowClassName { get; set; } = "";
 
+    // ── Browser web app (PWA) identity ───────────────────────────────────────
+    /// <summary>
+    /// Per-window <c>AppUserModelID</c> captured at snapshot time. For Chromium browsers this
+    /// distinguishes an installed web app window from an ordinary browser window.
+    /// Empty for non-browser apps and for snapshots taken before web-app support was added.
+    /// </summary>
+    public string  AppUserModelId        { get; set; } = "";
+
+    /// <summary>True when this entry is an installed browser web app (PWA), not a plain browser window.</summary>
+    public bool    IsWebApp              { get; set; }
+
+    /// <summary>Display name of the web app, taken from its shortcut (e.g. "Insilico Terminal").</summary>
+    public string  WebAppName            { get; set; } = "";
+
+    /// <summary>Path of the <c>.lnk</c> that launches the web app. Preferred launch method on restore.</summary>
+    public string? WebAppShortcutPath    { get; set; }
+
+    /// <summary>Shortcut target used when the <c>.lnk</c> no longer exists (usually <c>chrome_proxy.exe</c>).</summary>
+    public string? WebAppLaunchTarget    { get; set; }
+
+    /// <summary>Command line for <see cref="WebAppLaunchTarget"/>, e.g. <c>--profile-directory=Default --app-id=…</c>.</summary>
+    public string? WebAppLaunchArguments { get; set; }
+
     // ── File tracking (null when SavedWithFiles = false) ─────────────────────
     public string? FilePath       { get; set; }
     public int     FileConfidence { get; set; }

--- a/src/WindowAnchor/Native/NativeMethods.Shell.cs
+++ b/src/WindowAnchor/Native/NativeMethods.Shell.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace WindowAnchor.Native;
+
+/// <summary>
+/// P/Invoke and COM declarations for the Windows Shell property system.
+/// <para>
+/// Used to read the <c>AppUserModelID</c> (AUMID) of a window and of a
+/// <c>.lnk</c> shortcut.  This is the only reliable way to tell a Chrome/Brave/Edge
+/// <em>web-app window</em> (an installed PWA such as Insilico Terminal or aggr.trade)
+/// apart from an ordinary browser window: both live in the same
+/// <c>chrome.exe</c>/<c>brave.exe</c> process and use the same window class
+/// (<c>Chrome_WidgetWin_1</c>), but Chromium assigns every installed web app its own
+/// per-window AUMID so it gets its own taskbar group.
+/// </para>
+/// </summary>
+public static class NativeMethodsShell
+{
+    // ── Property system ───────────────────────────────────────────────────────
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct PropertyKey
+    {
+        public Guid FormatId;
+        public uint PropertyId;
+
+        public PropertyKey(Guid formatId, uint propertyId)
+        {
+            FormatId   = formatId;
+            PropertyId = propertyId;
+        }
+    }
+
+    /// <summary>PKEY_AppUserModel_ID — {9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}, 5.</summary>
+    public static readonly PropertyKey PKEY_AppUserModel_ID =
+        new(new Guid("9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3"), 5);
+
+    /// <summary>
+    /// Minimal PROPVARIANT wrapper. Only VT_LPWSTR / VT_BSTR values are read,
+    /// which is all PKEY_AppUserModel_ID ever contains.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public sealed class PropVariant : IDisposable
+    {
+        private ushort _vt;
+        private ushort _reserved1;
+        private ushort _reserved2;
+        private ushort _reserved3;
+        private IntPtr _pointer;
+        private IntPtr _pointer2;
+
+        private const ushort VT_EMPTY  = 0;
+        private const ushort VT_BSTR   = 8;
+        private const ushort VT_LPWSTR = 31;
+
+        /// <summary>Returns the string value, or <c>null</c> when the variant holds something else.</summary>
+        public string? AsString()
+        {
+            if (_vt is VT_LPWSTR or VT_BSTR)
+                return Marshal.PtrToStringUni(_pointer);
+            return null;
+        }
+
+        public bool IsEmpty => _vt == VT_EMPTY;
+
+        public void Dispose()
+        {
+            try { PropVariantClear(this); } catch { /* best effort */ }
+            _vt = VT_EMPTY;
+            GC.SuppressFinalize(this);
+        }
+
+        ~PropVariant() => Dispose();
+    }
+
+    [DllImport("ole32.dll")]
+    private static extern int PropVariantClear([In, Out] PropVariant pvar);
+
+    [ComImport]
+    [Guid("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IPropertyStore
+    {
+        [PreserveSig] int GetCount(out uint cProps);
+        [PreserveSig] int GetAt(uint iProp, out PropertyKey pkey);
+        [PreserveSig] int GetValue(ref PropertyKey key, [In, Out] PropVariant pv);
+        [PreserveSig] int SetValue(ref PropertyKey key, [In] PropVariant pv);
+        [PreserveSig] int Commit();
+    }
+
+    /// <summary>Returns the property store of a window (contains its AppUserModelID, if set).</summary>
+    [DllImport("shell32.dll", SetLastError = true)]
+    public static extern int SHGetPropertyStoreForWindow(
+        IntPtr hwnd,
+        ref Guid iid,
+        [MarshalAs(UnmanagedType.Interface)] out IPropertyStore propertyStore);
+
+    public static readonly Guid IID_IPropertyStore =
+        new("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99");
+
+    // ── Shell links (.lnk) ────────────────────────────────────────────────────
+
+    /// <summary>CLSID_ShellLink coclass — <c>new ShellLinkCoClass()</c> maps to CoCreateInstance.</summary>
+    [ComImport]
+    [Guid("00021401-0000-0000-C000-000000000046")]
+    public class ShellLinkCoClass { }
+
+    [ComImport]
+    [Guid("000214F9-0000-0000-C000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IShellLinkW
+    {
+        void GetPath([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile,
+                     int cchMaxPath, IntPtr pfd, uint fFlags);
+        void GetIDList(out IntPtr ppidl);
+        void SetIDList(IntPtr pidl);
+        void GetDescription([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszName, int cch);
+        void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+        void GetWorkingDirectory([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszDir, int cch);
+        void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
+        void GetArguments([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszArgs, int cch);
+        void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
+        void GetHotkey(out short pwHotkey);
+        void SetHotkey(short wHotkey);
+        void GetShowCmd(out int piShowCmd);
+        void SetShowCmd(int iShowCmd);
+        void GetIconLocation([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszIconPath,
+                             int cch, out int piIcon);
+        void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
+        void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, uint dwReserved);
+        void Resolve(IntPtr hwnd, uint fFlags);
+        void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
+    }
+
+    [ComImport]
+    [Guid("0000010b-0000-0000-C000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IPersistFile
+    {
+        void GetClassID(out Guid pClassID);
+        [PreserveSig] int IsDirty();
+        void Load([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, uint dwMode);
+        void Save([MarshalAs(UnmanagedType.LPWStr)] string? pszFileName,
+                  [MarshalAs(UnmanagedType.Bool)] bool fRemember);
+        void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string pszFileName);
+        void GetCurFile([MarshalAs(UnmanagedType.LPWStr)] out string ppszFileName);
+    }
+
+    /// <summary>SLGP_RAWPATH — return the unexpanded target path.</summary>
+    public const uint SLGP_RAWPATH = 0x4;
+
+    /// <summary>STGM_READ — open the .lnk read-only.</summary>
+    public const uint STGM_READ = 0x0;
+}

--- a/src/WindowAnchor/Native/NativeMethods.Shell.cs
+++ b/src/WindowAnchor/Native/NativeMethods.Shell.cs
@@ -153,4 +153,29 @@ public static class NativeMethodsShell
 
     /// <summary>STGM_READ — open the .lnk read-only.</summary>
     public const uint STGM_READ = 0x0;
+
+    // ── Packaged-process AppUserModelID ────────────────────────────────────────
+    // Store/MSIX apps (TradingView, Notepad, …) usually do NOT set an explicit AUMID on their
+    // window, so SHGetPropertyStoreForWindow returns nothing. The reliable source is the
+    // *process*: GetApplicationUserModelId returns "PackageFamilyName!AppId" for any packaged
+    // process. That AUMID is what shell:AppsFolder needs to relaunch the app with full package
+    // identity (and therefore its saved settings, e.g. dark theme).
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr OpenProcess(uint dwDesiredAccess,
+        [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwProcessId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool CloseHandle(IntPtr hObject);
+
+    /// <summary>Minimal access right needed to query a process's package identity.</summary>
+    public const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+
+    /// <summary>Returned by GetApplicationUserModelId when the process is not packaged.</summary>
+    public const int APPMODEL_ERROR_NO_APPLICATION = 15703;
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetApplicationUserModelId(
+        IntPtr hProcess, ref uint applicationUserModelIdLength, [Out] char[]? applicationUserModelId);
 }

--- a/src/WindowAnchor/Services/BrowserUrlService.cs
+++ b/src/WindowAnchor/Services/BrowserUrlService.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Automation;
+
+namespace WindowAnchor.Services;
+
+/// <summary>
+/// Reads the address-bar URL of a Chromium browser window via UI Automation.
+///
+/// <para><b>Why this exists.</b> Some trading tools are plain websites that cannot be installed
+/// as a web app (no PWA manifest), so the user keeps them in a dedicated browser window next to
+/// their normal multi-tab window. Both windows are indistinguishable to WindowAnchor: same
+/// executable, same window class, same (browser-level) AppUserModelID, and both are covered by
+/// <c>--restore-last-session</c>, which reopens the previous session rather than a specific
+/// window. Capturing the URL lets such a window be reopened deliberately with
+/// <c>--new-window &lt;url&gt;</c>.</para>
+///
+/// <para>Reading is opt-in via <see cref="Models.AppSettings.DedicatedBrowserUrlPatterns"/>: when
+/// no patterns are configured nothing is queried, so users who do not need the feature pay no
+/// cost during a snapshot.</para>
+/// </summary>
+public static class BrowserUrlService
+{
+    /// <summary>
+    /// Hard limit for a single UI Automation query. The accessibility tree of a browser window
+    /// can take a moment to materialise, and a snapshot must never hang on one window.
+    /// </summary>
+    private static readonly TimeSpan QueryTimeout = TimeSpan.FromMilliseconds(1500);
+
+    /// <summary>
+    /// Returns the URL shown in the address bar of <paramref name="hWnd"/>, or an empty string
+    /// when it cannot be determined (not a browser window, accessibility unavailable, timeout).
+    /// Never throws.
+    /// </summary>
+    public static string GetWindowUrl(IntPtr hWnd)
+    {
+        if (hWnd == IntPtr.Zero) return "";
+
+        try
+        {
+            // UI Automation can block for an unbounded time on an unresponsive window, so run it
+            // on a worker and give up after QueryTimeout rather than stalling the whole snapshot.
+            var task = Task.Run(() => ReadAddressBar(hWnd));
+            return task.Wait(QueryTimeout) ? task.Result : "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Debug($"[BrowserUrl] query failed for hwnd {hWnd}: {ex.Message}");
+            return "";
+        }
+    }
+
+    /// <summary>
+    /// Finds the address bar inside a Chromium window and returns its value.
+    /// Chromium exposes it as an Edit control supporting <c>ValuePattern</c>; the control's name
+    /// is localised, so it is located by control type rather than by name.
+    /// </summary>
+    private static string ReadAddressBar(IntPtr hWnd)
+    {
+        try
+        {
+            var root = AutomationElement.FromHandle(hWnd);
+            if (root == null) return "";
+
+            var edits = root.FindAll(
+                TreeScope.Descendants,
+                new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Edit));
+
+            foreach (AutomationElement edit in edits)
+            {
+                try
+                {
+                    if (!edit.TryGetCurrentPattern(ValuePattern.Pattern, out object pattern))
+                        continue;
+
+                    string value = ((ValuePattern)pattern).Current.Value ?? "";
+                    if (string.IsNullOrWhiteSpace(value)) continue;
+
+                    return NormalizeUrl(value);
+                }
+                catch { /* individual element vanished mid-query — try the next one */ }
+            }
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Debug($"[BrowserUrl] ReadAddressBar failed: {ex.Message}");
+        }
+
+        return "";
+    }
+
+    /// <summary>
+    /// Turns what the address bar displays into a launchable URL. Chromium hides the scheme, so
+    /// "vari.love/trade" is shown where the real URL is "https://vari.love/trade". Text that is
+    /// clearly not an address (a search term the user is typing) is rejected.
+    /// </summary>
+    public static string NormalizeUrl(string raw)
+    {
+        string value = raw.Trim();
+        if (value.Length == 0) return "";
+
+        if (value.StartsWith("http://",  StringComparison.OrdinalIgnoreCase) ||
+            value.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            return value;
+
+        // Reject anything that cannot be a bare host: needs a dot and no whitespace.
+        if (value.Contains(' ') || !value.Contains('.')) return "";
+
+        return "https://" + value;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="url"/> matches any entry of
+    /// <paramref name="patterns"/>. Matching is a case-insensitive substring test, so a bare
+    /// domain such as <c>vari.love</c> matches every page on that site.
+    /// </summary>
+    public static bool MatchesAnyPattern(string url, IEnumerable<string>? patterns)
+    {
+        if (string.IsNullOrWhiteSpace(url) || patterns == null) return false;
+
+        return patterns
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Any(p => url.Contains(p.Trim(), StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/WindowAnchor/Services/LayoutCoordinator.cs
+++ b/src/WindowAnchor/Services/LayoutCoordinator.cs
@@ -84,6 +84,23 @@ public class LayoutCoordinator
     }
 
     /// <summary>
+    /// Restores a workspace and then minimizes every window that is not part of it (nothing is
+    /// closed). This brings the workspace's own windows to their saved positions and clears away
+    /// unrelated windows — a non-destructive middle ground between Restore (leaves other windows
+    /// untouched) and Switch (closes everything else first).
+    /// </summary>
+    public async Task AlignAndMinimizeOthersAsync(WorkspaceSnapshot snapshot, CancellationToken token = default)
+    {
+        AppLogger.Info($"AlignAndMinimizeOthersAsync: \u2018{snapshot.Name}\u2019");
+        NotifyBalloon("Aligning\u2026",
+            $"\u201c{snapshot.Name}\u201d \u2014 positioning its windows and minimizing everything else.");
+        await _workspaceService.RestoreWorkspaceAlignAndMinimizeAsync(snapshot, token);
+        if (!token.IsCancellationRequested)
+            NotifyBalloon("Workspace Aligned",
+                $"\u201c{snapshot.Name}\u201d \u2014 other windows were minimized, not closed.");
+    }
+
+    /// <summary>
     /// Restores only entries on the specified monitors and shows a completion balloon.
     /// When <paramref name="monitorIds"/> is <c>null</c> all monitors are restored.
     /// </summary>

--- a/src/WindowAnchor/Services/WebAppService.cs
+++ b/src/WindowAnchor/Services/WebAppService.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using WindowAnchor.Native;
+
+namespace WindowAnchor.Services;
+
+/// <summary>
+/// Describes an installed browser web app (PWA / "Create shortcut… → Open as window"),
+/// e.g. Insilico Terminal or aggr.trade installed from Chrome or Brave.
+/// </summary>
+/// <param name="AppUserModelId">Per-window AUMID Chromium assigns to the app window.</param>
+/// <param name="ShortcutPath">Full path of the Start-Menu/Desktop <c>.lnk</c> that launches it.</param>
+/// <param name="TargetPath">Shortcut target (usually <c>chrome_proxy.exe</c> or <c>chrome.exe</c>).</param>
+/// <param name="Arguments">Shortcut arguments, e.g. <c>--profile-directory=Default --app-id=abc…</c>.</param>
+/// <param name="DisplayName">Shortcut file name without extension, used for logging/UI.</param>
+public record WebAppInfo(
+    string AppUserModelId,
+    string ShortcutPath,
+    string TargetPath,
+    string Arguments,
+    string DisplayName);
+
+/// <summary>
+/// Identifies browser web-app windows and resolves how to relaunch them.
+///
+/// <para><b>The problem this solves.</b> An installed web app (Insilico Terminal,
+/// aggr.trade, …) opens in the ordinary <c>chrome.exe</c> / <c>brave.exe</c> process and
+/// uses the same window class as a normal browser window. Identifying a window only by
+/// executable path + class name therefore makes every PWA window look like "a Chrome
+/// window", so restoring a layout launched a plain browser instead of the app.</para>
+///
+/// <para><b>The fix.</b> Chromium sets a distinct <c>AppUserModelID</c> on every web-app
+/// window (that is how the app gets its own taskbar icon). We read that AUMID per window,
+/// store it in the snapshot, and match it against the AUMID recorded on the Start-Menu
+/// shortcut Chromium created when the app was installed. Restoring then launches that
+/// shortcut, and window matching requires an exact AUMID match so a PWA entry can never
+/// consume a plain browser window (or vice versa).</para>
+/// </summary>
+public class WebAppService
+{
+    /// <summary>Chromium-based browsers whose windows may actually be web-app windows.</summary>
+    private static readonly HashSet<string> ChromiumProcessNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "chrome", "msedge", "brave", "opera", "opera_gx", "vivaldi", "chromium", "thorium", "arc",
+    };
+
+    // AUMID (lower-case) → web app. Null until the first lookup builds it.
+    private Dictionary<string, WebAppInfo>? _shortcutIndex;
+
+    // When the index was last built. A lookup miss is the normal case for every plain browser
+    // window, so the index must NOT be rebuilt on every miss — that would rescan the whole
+    // Start Menu once per browser window. Rebuild at most once per this interval.
+    private DateTime _indexBuiltAt = DateTime.MinValue;
+    private static readonly TimeSpan RebuildCooldown = TimeSpan.FromMinutes(2);
+
+    /// <summary>Returns <c>true</c> when the process is a Chromium-based browser.</summary>
+    public static bool IsChromiumBrowser(string processName) =>
+        ChromiumProcessNames.Contains(processName.Replace(".exe", "", StringComparison.OrdinalIgnoreCase));
+
+    // ── Per-window AUMID ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Reads the explicit <c>AppUserModelID</c> of a window via
+    /// <c>SHGetPropertyStoreForWindow</c>. Returns an empty string when the window has no
+    /// explicit AUMID (which is the normal case for most classic desktop apps).
+    /// </summary>
+    public static string GetWindowAppUserModelId(IntPtr hWnd)
+    {
+        NativeMethodsShell.IPropertyStore? store = null;
+        try
+        {
+            var iid = NativeMethodsShell.IID_IPropertyStore;
+            int hr = NativeMethodsShell.SHGetPropertyStoreForWindow(hWnd, ref iid, out store);
+            if (hr != 0 || store == null) return "";
+
+            using var pv = new NativeMethodsShell.PropVariant();
+            var key = NativeMethodsShell.PKEY_AppUserModel_ID;
+            if (store.GetValue(ref key, pv) != 0) return "";
+
+            return pv.AsString() ?? "";
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Debug($"[WebApp] GetWindowAppUserModelId failed for hwnd {hWnd}: {ex.Message}");
+            return "";
+        }
+        finally
+        {
+            if (store != null) Marshal.ReleaseComObject(store);
+        }
+    }
+
+    // ── Shortcut index ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Looks up the installed web app whose shortcut carries <paramref name="aumid"/>.
+    /// Rebuilds the shortcut index once on a miss so newly installed apps are picked up
+    /// without restarting WindowAnchor.
+    /// </summary>
+    public WebAppInfo? FindByAumid(string aumid)
+    {
+        if (string.IsNullOrWhiteSpace(aumid)) return null;
+
+        string key = aumid.ToLowerInvariant();
+
+        if (_shortcutIndex == null)
+        {
+            _shortcutIndex = BuildShortcutIndex();
+            _indexBuiltAt  = DateTime.UtcNow;
+        }
+
+        if (_shortcutIndex.TryGetValue(key, out var hit)) return hit;
+
+        // Miss. Most misses are ordinary browser windows (AUMID "Chrome", "Brave", …), so only
+        // rescan when the index is stale — otherwise a newly installed web app would never be
+        // picked up, but every plain browser window would trigger a full Start-Menu scan.
+        if (!WebAppService.LooksLikeWebAppAumid(aumid)) return null;
+        if (DateTime.UtcNow - _indexBuiltAt < RebuildCooldown) return null;
+
+        _shortcutIndex = BuildShortcutIndex();
+        _indexBuiltAt  = DateTime.UtcNow;
+        return _shortcutIndex.TryGetValue(key, out hit) ? hit : null;
+    }
+
+    /// <summary>Forces the next lookup to re-scan the Start Menu and Desktop.</summary>
+    public void InvalidateCache()
+    {
+        _shortcutIndex = null;
+        _indexBuiltAt  = DateTime.MinValue;
+    }
+
+    /// <summary>
+    /// Scans the Start Menu and Desktop (user + all-users) for <c>.lnk</c> files that carry
+    /// an explicit AUMID <em>and</em> a Chromium app switch (<c>--app-id=</c> or <c>--app=</c>).
+    /// Those are exactly the shortcuts Chromium writes when a web app is installed.
+    /// </summary>
+    private Dictionary<string, WebAppInfo> BuildShortcutIndex()
+    {
+        var index = new Dictionary<string, WebAppInfo>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var root in GetShortcutRoots())
+        {
+            foreach (var lnk in EnumerateShortcuts(root))
+            {
+                try
+                {
+                    var info = ReadShortcut(lnk);
+                    if (info == null) continue;
+                    if (string.IsNullOrEmpty(info.AppUserModelId)) continue;
+                    if (!HasChromiumAppSwitch(info.Arguments)) continue;
+
+                    // First match wins (user Start Menu is scanned before all-users/desktop).
+                    index.TryAdd(info.AppUserModelId.ToLowerInvariant(), info);
+                }
+                catch (Exception ex)
+                {
+                    AppLogger.Debug($"[WebApp] shortcut '{lnk}' unreadable: {ex.Message}");
+                }
+            }
+        }
+
+        AppLogger.Info($"[WebApp] shortcut index built — {index.Count} installed web app(s) found");
+        return index;
+    }
+
+    private static IEnumerable<string> GetShortcutRoots()
+    {
+        var roots = new List<string>
+        {
+            Environment.GetFolderPath(Environment.SpecialFolder.StartMenu),
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu),
+            Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonDesktopDirectory),
+        };
+
+        return roots.Where(r => !string.IsNullOrEmpty(r) && Directory.Exists(r))
+                    .Distinct(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Recursive .lnk enumeration that tolerates per-folder access errors.</summary>
+    private static IEnumerable<string> EnumerateShortcuts(string directory)
+    {
+        // No yield inside try/catch: collect first, then yield.
+        string[] files = Array.Empty<string>();
+        try { files = Directory.GetFiles(directory, "*.lnk"); } catch { /* unreadable folder */ }
+
+        foreach (var f in files) yield return f;
+
+        string[] subDirs = Array.Empty<string>();
+        try { subDirs = Directory.GetDirectories(directory); } catch { /* unreadable folder */ }
+
+        foreach (var sub in subDirs)
+            foreach (var f in EnumerateShortcuts(sub))
+                yield return f;
+    }
+
+    /// <summary>Reads target, arguments and AUMID out of a <c>.lnk</c> file.</summary>
+    private static WebAppInfo? ReadShortcut(string lnkPath)
+    {
+        object? comObj = null;
+        try
+        {
+            comObj = new NativeMethodsShell.ShellLinkCoClass();
+            var link    = (NativeMethodsShell.IShellLinkW)comObj;
+            var persist = (NativeMethodsShell.IPersistFile)comObj;
+
+            persist.Load(lnkPath, NativeMethodsShell.STGM_READ);
+
+            var target = new StringBuilder(1024);
+            link.GetPath(target, target.Capacity, IntPtr.Zero, NativeMethodsShell.SLGP_RAWPATH);
+
+            var args = new StringBuilder(2048);
+            link.GetArguments(args, args.Capacity);
+
+            string aumid = "";
+            if (comObj is NativeMethodsShell.IPropertyStore store)
+            {
+                using var pv = new NativeMethodsShell.PropVariant();
+                var key = NativeMethodsShell.PKEY_AppUserModel_ID;
+                if (store.GetValue(ref key, pv) == 0)
+                    aumid = pv.AsString() ?? "";
+            }
+
+            return new WebAppInfo(
+                AppUserModelId: aumid,
+                ShortcutPath:   lnkPath,
+                TargetPath:     target.ToString(),
+                Arguments:      args.ToString(),
+                DisplayName:    Path.GetFileNameWithoutExtension(lnkPath));
+        }
+        finally
+        {
+            if (comObj != null) Marshal.ReleaseComObject(comObj);
+        }
+    }
+
+    // ── Heuristics ────────────────────────────────────────────────────────────
+
+    /// <summary>True when the argument string contains a Chromium app-mode switch.</summary>
+    public static bool HasChromiumAppSwitch(string arguments) =>
+        arguments.Contains("--app-id=", StringComparison.OrdinalIgnoreCase) ||
+        arguments.Contains("--app=",    StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Fallback detection when no shortcut is found: Chromium web-app AUMIDs end in the
+    /// 32-character extension-style app id (characters <c>a</c>–<c>p</c>) or use the legacy
+    /// <c>_crx_</c> prefix. A plain browser window's AUMID is just <c>Chrome</c>,
+    /// <c>Brave</c>, <c>Chrome.&lt;profilehash&gt;</c> etc.
+    /// </summary>
+    public static bool LooksLikeWebAppAumid(string aumid)
+    {
+        if (string.IsNullOrWhiteSpace(aumid)) return false;
+        if (aumid.Contains("_crx_", StringComparison.OrdinalIgnoreCase)) return true;
+
+        // Chromium app ids are lower-case a–p strings. 32 characters is the documented length,
+        // but real installs also produce shorter ids (observed: 26), so accept a range.
+        // A plain browser AUMID is "Chrome", "Brave" or "Chrome.<hex profile hash>" and never
+        // reaches this length in the a–p alphabet.
+        string last = aumid.Split('.').Last();
+        return IsChromiumAppId(last);
+    }
+
+    /// <summary>True for a Chromium extension/app id: 20–32 characters from the a–p alphabet.</summary>
+    private static bool IsChromiumAppId(string candidate) =>
+        candidate.Length is >= 20 and <= 32 && candidate.All(c => c is >= 'a' and <= 'p');
+
+    /// <summary>
+    /// Extracts the 32-character Chromium app id from an AUMID, or <c>null</c>.
+    /// Used to build a <c>--app-id=</c> command line when the shortcut is missing.
+    /// </summary>
+    public static string? ExtractAppIdFromAumid(string aumid)
+    {
+        if (string.IsNullOrWhiteSpace(aumid)) return null;
+
+        int crx = aumid.IndexOf("_crx_", StringComparison.OrdinalIgnoreCase);
+        if (crx >= 0)
+        {
+            // Everything after "_crx_" is the app id — its length varies (26 and 32 both occur).
+            string tail = aumid[(crx + 5)..].Split('.')[0];
+            return tail.Length > 0 ? tail : null;
+        }
+
+        string last = aumid.Split('.').Last();
+        return IsChromiumAppId(last) ? last : null;
+    }
+}

--- a/src/WindowAnchor/Services/WebAppService.cs
+++ b/src/WindowAnchor/Services/WebAppService.cs
@@ -61,6 +61,25 @@ public class WebAppService
     public static bool IsChromiumBrowser(string processName) =>
         ChromiumProcessNames.Contains(processName.Replace(".exe", "", StringComparison.OrdinalIgnoreCase));
 
+    // ── Friendly display name ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns a human-friendly name for a window when it is an installed browser web app
+    /// (e.g. "Insilico Terminal" instead of "brave"), or <c>null</c> for anything else.
+    /// Purely cosmetic — used by the Save Workspace dialog.
+    /// </summary>
+    public string? ResolveWebAppName(string processName, string appUserModelId)
+    {
+        if (!IsChromiumBrowser(processName))     return null;
+        if (string.IsNullOrEmpty(appUserModelId)) return null;
+
+        var info = FindByAumid(appUserModelId);
+        if (info != null) return info.DisplayName;
+
+        // Shortcut missing but the AUMID still looks like a web app — fall back to the app id.
+        return LooksLikeWebAppAumid(appUserModelId) ? "Web App" : null;
+    }
+
     // ── Per-window AUMID ──────────────────────────────────────────────────────
 
     /// <summary>
@@ -91,6 +110,45 @@ public class WebAppService
         finally
         {
             if (store != null) Marshal.ReleaseComObject(store);
+        }
+    }
+
+    /// <summary>
+    /// Returns the <c>AppUserModelID</c> of a running process from its package identity, or an
+    /// empty string when the process is not a packaged (Store/MSIX) app or cannot be queried.
+    /// <para>
+    /// This is the reliable AUMID source for Store apps, whose windows typically carry no
+    /// explicit AUMID property. The result (<c>PackageFamilyName!AppId</c>) is what
+    /// <c>shell:AppsFolder</c> needs to relaunch the app with full package identity.
+    /// </para>
+    /// </summary>
+    public static string GetProcessAppUserModelId(uint processId)
+    {
+        IntPtr hProcess = NativeMethodsShell.OpenProcess(
+            NativeMethodsShell.PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
+        if (hProcess == IntPtr.Zero) return "";
+
+        try
+        {
+            uint length = 0;
+            // First call: probe the required buffer length (expected ERROR_INSUFFICIENT_BUFFER).
+            NativeMethodsShell.GetApplicationUserModelId(hProcess, ref length, null);
+            if (length == 0) return "";
+
+            var buffer = new char[length];
+            int rc = NativeMethodsShell.GetApplicationUserModelId(hProcess, ref length, buffer);
+            if (rc != 0) return "";   // non-zero incl. APPMODEL_ERROR_NO_APPLICATION → not packaged
+
+            return new string(buffer, 0, (int)length).TrimEnd('\0');
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Debug($"[WebApp] GetProcessAppUserModelId({processId}) failed: {ex.Message}");
+            return "";
+        }
+        finally
+        {
+            NativeMethodsShell.CloseHandle(hProcess);
         }
     }
 

--- a/src/WindowAnchor/Services/WindowService.cs
+++ b/src/WindowAnchor/Services/WindowService.cs
@@ -18,6 +18,17 @@ namespace WindowAnchor.Services;
 /// </summary>
 public class WindowService
 {
+    private readonly SettingsService? _settingsService;
+
+    /// <param name="settingsService">
+    ///   Optional. Supplies <see cref="Models.AppSettings.DedicatedBrowserUrlPatterns"/>; when
+    ///   omitted no browser URLs are read during a snapshot.
+    /// </param>
+    public WindowService(SettingsService? settingsService = null)
+    {
+        _settingsService = settingsService;
+    }
+
     // Skip-list of well-known OS-chrome window classes that should never be saved.
     private static readonly string[] OsWindowClassSkipList = new[]
     {
@@ -230,6 +241,21 @@ public class WindowService
             appUserModelId = WebAppService.GetProcessAppUserModelId(processId);
         }
 
+        // For browser windows, read the address bar only when the user configured URL patterns
+        // and the window's URL matches one. This keeps the (comparatively slow) UI Automation
+        // query off the snapshot path for everyone who does not use the feature.
+        string browserUrl = "";
+        var urlPatterns = _settingsService?.Settings.DedicatedBrowserUrlPatterns;
+        if (urlPatterns is { Count: > 0 } && WebAppService.IsChromiumBrowser(processName))
+        {
+            string url = BrowserUrlService.GetWindowUrl(hWnd);
+            if (BrowserUrlService.MatchesAnyPattern(url, urlPatterns))
+            {
+                browserUrl = url;
+                AppLogger.Info($"[BrowserUrl] dedicated window matched: {url}");
+            }
+        }
+
         // For File Explorer windows, resolve the open folder via the pre-built COM map
         string folderPath = "";
         if (explorerFolderMap != null &&
@@ -253,6 +279,7 @@ public class WindowService
             SavedDpi = NativeMethodsWindow.GetDpiForWindow(hWnd),
             FolderPath = folderPath,
             AppUserModelId = appUserModelId,
+            BrowserUrl = browserUrl,
         };
     }
 
@@ -402,6 +429,35 @@ public class WindowService
 
         AppLogger.Info($"CloseAllUserWindows: sent WM_CLOSE to {closed} windows");
         return closed;
+    }
+
+    /// <summary>
+    /// Minimizes every visible top-level user window whose handle is <em>not</em> in
+    /// <paramref name="keep"/>. WindowAnchor's own windows are always left alone.
+    /// Used by the "align &amp; minimize others" restore mode to clear away windows that are not
+    /// part of the workspace without closing them. Returns the number of windows minimized.
+    /// </summary>
+    public int MinimizeUserWindowsExcept(HashSet<IntPtr> keep)
+    {
+        const int SW_MINIMIZE = 6;   // minimize without activating another window
+        int minimized = 0;
+        var ownPid = (uint)Process.GetCurrentProcess().Id;
+
+        NativeMethodsWindow.EnumWindows((hWnd, _) =>
+        {
+            if (!ShouldIncludeWindow(hWnd)) return true;
+            if (keep.Contains(hWnd)) return true;
+
+            NativeMethodsWindow.GetWindowThreadProcessId(hWnd, out uint pid);
+            if (pid == ownPid) return true;   // never touch our own windows
+
+            NativeMethodsWindow.ShowWindow(hWnd, SW_MINIMIZE);
+            minimized++;
+            return true;
+        }, IntPtr.Zero);
+
+        AppLogger.Info($"MinimizeUserWindowsExcept: minimized {minimized} window(s) not in the workspace");
+        return minimized;
     }
 
     /// <summary>

--- a/src/WindowAnchor/Services/WindowService.cs
+++ b/src/WindowAnchor/Services/WindowService.cs
@@ -221,6 +221,15 @@ public class WindowService
         // Classic desktop apps usually have no explicit AUMID — the empty string is expected.
         string appUserModelId = WebAppService.GetWindowAppUserModelId(hWnd);
 
+        // Fallback for packaged (Store/MSIX) apps: their windows usually carry no explicit AUMID,
+        // so read it from the process's package identity instead. This is what lets us relaunch
+        // TradingView, Notepad, … via shell:AppsFolder with their settings intact.
+        if (string.IsNullOrEmpty(appUserModelId) &&
+            exePath.Contains(@"\WindowsApps\", StringComparison.OrdinalIgnoreCase))
+        {
+            appUserModelId = WebAppService.GetProcessAppUserModelId(processId);
+        }
+
         // For File Explorer windows, resolve the open folder via the pre-built COM map
         string folderPath = "";
         if (explorerFolderMap != null &&

--- a/src/WindowAnchor/Services/WindowService.cs
+++ b/src/WindowAnchor/Services/WindowService.cs
@@ -212,6 +212,15 @@ public class WindowService
         // lookups to run on windows where Tier 1 would have succeeded.
         string snippet = fullTitle.Length > 200 ? fullTitle.Substring(0, 200) : fullTitle;
 
+        // Read the window's explicit AppUserModelID. Two things depend on it:
+        //   • Chromium browsers: installed web apps (PWAs) get their own AUMID while sharing
+        //     chrome.exe/brave.exe and the window class — the only way to tell them apart.
+        //   • Store/MSIX apps (TradingView, Notepad, …): the AUMID is the only way to relaunch
+        //     them *with package identity*. Starting their exe under C:\Program Files\WindowsApps
+        //     directly gives the app no package container, so it loses its settings.
+        // Classic desktop apps usually have no explicit AUMID — the empty string is expected.
+        string appUserModelId = WebAppService.GetWindowAppUserModelId(hWnd);
+
         // For File Explorer windows, resolve the open folder via the pre-built COM map
         string folderPath = "";
         if (explorerFolderMap != null &&
@@ -234,6 +243,7 @@ public class WindowService
             NormalBottom = placement.RcNormalPosition.Bottom,
             SavedDpi = NativeMethodsWindow.GetDpiForWindow(hWnd),
             FolderPath = folderPath,
+            AppUserModelId = appUserModelId,
         };
     }
 

--- a/src/WindowAnchor/Services/WorkspaceService.cs
+++ b/src/WindowAnchor/Services/WorkspaceService.cs
@@ -229,6 +229,14 @@ public class WorkspaceService
                 continue;
             }
 
+            // ── Dedicated browser window (site kept in its own window) ─────
+            var urlEntry = TryBuildDedicatedBrowserEntry(w);
+            if (urlEntry != null)
+            {
+                entries.Add(urlEntry);
+                continue;
+            }
+
             // ── Explorer special case ──────────────────────────────────────
             if (w.ProcessName.Equals("explorer", StringComparison.OrdinalIgnoreCase) &&
                 !string.IsNullOrEmpty(w.FolderPath))
@@ -511,6 +519,40 @@ public class WorkspaceService
         };
     }
 
+    /// <summary>
+    /// Builds a <see cref="WorkspaceEntry"/> for a browser window that the user keeps at a
+    /// specific site in its own window, or <c>null</c> when the window is not one of those.
+    /// <para>
+    /// A window qualifies when <see cref="WindowRecord.BrowserUrl"/> was populated during capture,
+    /// which only happens for a Chromium window whose address bar matched a configured
+    /// <see cref="Models.AppSettings.DedicatedBrowserUrlPatterns"/> entry.
+    /// </para>
+    /// </summary>
+    private WorkspaceEntry? TryBuildDedicatedBrowserEntry(WindowRecord w)
+    {
+        if (string.IsNullOrEmpty(w.BrowserUrl)) return null;
+
+        AppLogger.Info($"[BrowserUrl] '{w.BrowserUrl}' saved as a dedicated {w.ProcessName} window");
+
+        return new WorkspaceEntry
+        {
+            ExecutablePath           = w.ExecutablePath,
+            ProcessName              = w.ProcessName,
+            WindowClassName          = w.ClassName,
+            AppUserModelId           = w.AppUserModelId,
+            FilePath                 = null,
+            FileConfidence           = 0,
+            FileSource               = "BROWSER_URL",
+            LaunchArg                = null,   // must stay null: not a document entry
+            IsDedicatedBrowserWindow = true,
+            BrowserUrl               = w.BrowserUrl,
+            Position                 = w,
+            MonitorId                = w.MonitorId,
+            MonitorIndex             = w.MonitorIndex,
+            MonitorName              = w.MonitorName,
+        };
+    }
+
     // ── Per-window entry builder (shared by both snapshot paths) ──────────
 
     /// <summary>
@@ -524,6 +566,10 @@ public class WorkspaceService
         // web-app window is treated as a generic browser window.
         var webAppEntry = TryBuildWebAppEntry(w);
         if (webAppEntry != null) return webAppEntry;
+
+        // Dedicated browser window (site kept in its own window)
+        var urlEntry = TryBuildDedicatedBrowserEntry(w);
+        if (urlEntry != null) return urlEntry;
 
         // Explorer special case
         if (w.ProcessName.Equals("explorer", StringComparison.OrdinalIgnoreCase) &&
@@ -700,18 +746,33 @@ public class WorkspaceService
     ///   <item>2-second wait + second pass for slow launchers (Office, IDEs).</item>
     /// </list>
     /// </summary>
-    public async Task RestoreWorkspaceAsync(WorkspaceSnapshot snapshot, CancellationToken ct = default)
+    public Task RestoreWorkspaceAsync(WorkspaceSnapshot snapshot, CancellationToken ct = default)
+        => RestoreCoreAsync(snapshot, minimizeOthers: false, ct);
+
+    /// <summary>
+    /// Same as <see cref="RestoreWorkspaceAsync"/>, but after repositioning the workspace's own
+    /// windows it minimizes every other open window (nothing is closed). Use this to bring a
+    /// workspace to the foreground and clear away unrelated windows without the destructive
+    /// close-everything behaviour of <c>SwitchWorkspaceAsync</c>.
+    /// </summary>
+    public Task RestoreWorkspaceAlignAndMinimizeAsync(WorkspaceSnapshot snapshot, CancellationToken ct = default)
+        => RestoreCoreAsync(snapshot, minimizeOthers: true, ct);
+
+    private async Task RestoreCoreAsync(WorkspaceSnapshot snapshot, bool minimizeOthers, CancellationToken ct)
     {
-        AppLogger.Info($"RestoreWorkspaceAsync '{snapshot.Name}' — {snapshot.Entries.Count} entries");
+        AppLogger.Info($"RestoreCoreAsync '{snapshot.Name}' — {snapshot.Entries.Count} entries, minimizeOthers={minimizeOthers}");
 
         // ── Phase 1: reposition already-running windows ───────────────────
         // correctlyMatchedEntries tracks entries whose live window already had the right
         // document open (title matched). Only those entries are skipped in Phase 2.
+        // matchedHwnds accumulates every live window we repositioned, so "align & minimize
+        // others" knows which windows belong to the workspace and must be left visible.
         var liveWindows = _windowService.GetAllWindowsWithPids();
         var restoredEntries = new HashSet<int>();
         var correctlyMatchedEntries = new HashSet<int>();
+        var matchedHwnds = new HashSet<IntPtr>();
 
-        MatchAndRestore(snapshot.Entries, liveWindows, restoredEntries, correctlyMatchedEntries);
+        MatchAndRestore(snapshot.Entries, liveWindows, restoredEntries, correctlyMatchedEntries, matchedHwnds);
 
         if (ct.IsCancellationRequested) return;
 
@@ -730,8 +791,11 @@ public class WorkspaceService
         bool anyLaunched = false;
         // Web-app windows must not count as "the browser is already running": a Chrome window
         // that is really the Insilico Terminal PWA should not suppress launching Chrome itself.
+        // Dedicated single-site windows are excluded for the same reason: a Brave window that is
+        // really the trading site must not suppress launching the user's normal Brave window.
         var runningExes = liveWindows.Values
             .Where(v => !IsWebAppWindow(v.Record))
+            .Where(v => string.IsNullOrEmpty(v.Record.BrowserUrl))
             .Select(v => v.Record.ExecutablePath.ToLowerInvariant())
             .ToHashSet();
 
@@ -766,6 +830,26 @@ public class WorkspaceService
                 catch (Exception ex)
                 {
                     AppLogger.Warn($"Failed to launch web app '{entry.WebAppName}': {ex.Message}");
+                }
+                continue;
+            }
+
+            // ── Dedicated browser window ──────────────────────────────────
+            // Open the site in its own window. Unlike --restore-last-session this targets one
+            // specific window, so it can coexist with the user's normal multi-tab window.
+            if (entry.IsDedicatedBrowserWindow)
+            {
+                if (restoredEntries.Contains(i)) continue;
+
+                try
+                {
+                    Process.Start(BuildProcessStartInfo(entry));
+                    anyLaunched = true;
+                    AppLogger.Info($"Opened dedicated browser window: {entry.BrowserUrl}");
+                }
+                catch (Exception ex)
+                {
+                    AppLogger.Warn($"Failed to open '{entry.BrowserUrl}': {ex.Message}");
                 }
                 continue;
             }
@@ -825,7 +909,15 @@ public class WorkspaceService
             }
         }
 
-        if (!anyLaunched) return;
+        if (!anyLaunched)
+        {
+            // Nothing new to launch — every workspace window was already open and repositioned in
+            // Phase 1. Still honour the minimize request before returning, otherwise "align &
+            // minimize others" would do nothing when the workspace is already fully open.
+            if (minimizeOthers && !ct.IsCancellationRequested)
+                _windowService.MinimizeUserWindowsExcept(matchedHwnds);
+            return;
+        }
 
         // ── Phase 3: wait for app initialisation ─────────────────────────
         await Task.Delay(3000, ct).ConfigureAwait(false);
@@ -833,7 +925,7 @@ public class WorkspaceService
 
         // ── Phase 4: reposition newly appeared windows ────────────────────
         liveWindows = _windowService.GetAllWindowsWithPids();
-        MatchAndRestore(snapshot.Entries, liveWindows, restoredEntries, correctlyMatchedEntries);
+        MatchAndRestore(snapshot.Entries, liveWindows, restoredEntries, correctlyMatchedEntries, matchedHwnds);
 
         if (ct.IsCancellationRequested) return;
 
@@ -842,9 +934,13 @@ public class WorkspaceService
         if (ct.IsCancellationRequested) return;
 
         liveWindows = _windowService.GetAllWindowsWithPids();
-        MatchAndRestore(snapshot.Entries, liveWindows, restoredEntries, correctlyMatchedEntries);
+        MatchAndRestore(snapshot.Entries, liveWindows, restoredEntries, correctlyMatchedEntries, matchedHwnds);
 
-        AppLogger.Info($"RestoreWorkspaceAsync complete");
+        // ── Optional: minimize everything that is not part of the workspace ──
+        if (minimizeOthers && !ct.IsCancellationRequested)
+            _windowService.MinimizeUserWindowsExcept(matchedHwnds);
+
+        AppLogger.Info($"RestoreCoreAsync complete");
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
@@ -870,7 +966,8 @@ public class WorkspaceService
         List<WorkspaceEntry> entries,
         Dictionary<IntPtr, (uint Pid, WindowRecord Record)> liveWindows,
         HashSet<int> restoredEntries,
-        HashSet<int>? correctlyMatchedEntries = null)
+        HashSet<int>? correctlyMatchedEntries = null,
+        HashSet<IntPtr>? matchedHwnds = null)
     {
         // Build a consumed-hwnd set so each window only gets one entry applied.
         var consumedHwnds = new HashSet<IntPtr>();
@@ -882,6 +979,15 @@ public class WorkspaceService
         // Entries from older snapshots carry no AUMID and simply never claim a web-app window.
         static bool IdentityCompatible(WorkspaceEntry e, WindowRecord rec)
         {
+            // A dedicated browser window and a normal browser window are the same executable and
+            // class, so without this guard either could claim the other's window.
+            bool liveIsDedicated = !string.IsNullOrEmpty(rec.BrowserUrl);
+            if (e.IsDedicatedBrowserWindow || liveIsDedicated)
+            {
+                if (e.IsDedicatedBrowserWindow != liveIsDedicated) return false;
+                if (liveIsDedicated && !SameSite(rec.BrowserUrl, e.BrowserUrl)) return false;
+            }
+
             string liveAumid = rec.AppUserModelId ?? "";
             if (!e.IsWebApp && !WebAppService.LooksLikeWebAppAumid(liveAumid))
                 return true;   // both sides are ordinary windows — old behaviour
@@ -912,6 +1018,28 @@ public class WorkspaceService
                     {
                         bestHwnd = hwnd;
                         titleMatched = true;   // right app is on screen — no relaunch needed
+                        break;
+                    }
+                }
+            }
+
+            // ── Tier -0.5: dedicated browser window match by URL ──────────────────
+            // The saved URL is the only stable identifier here: the title of such a window is
+            // just the page title and changes as the user navigates within the site.
+            if (entry.IsDedicatedBrowserWindow && !string.IsNullOrEmpty(entry.BrowserUrl))
+            {
+                foreach (var (hwnd, (_, rec)) in liveWindows)
+                {
+                    if (consumedHwnds.Contains(hwnd)) continue;
+                    if (string.IsNullOrEmpty(rec.BrowserUrl)) continue;
+                    if (!rec.ExecutablePath.Equals(entry.ExecutablePath, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    // Same site is enough — the user may have navigated to another page on it.
+                    if (SameSite(rec.BrowserUrl, entry.BrowserUrl))
+                    {
+                        bestHwnd = hwnd;
+                        titleMatched = true;   // correct window already open — no relaunch needed
                         break;
                     }
                 }
@@ -1020,12 +1148,29 @@ public class WorkspaceService
 
             consumedHwnds.Add(bestHwnd);
             restoredEntries.Add(i);
+            matchedHwnds?.Add(bestHwnd);
             if (titleMatched) correctlyMatchedEntries?.Add(i);
             entry.WasRestored = true;
 
             _windowService.RestoreSingleWindow(bestHwnd, entry.Position);
             AppLogger.Info($"Restored entry[{i}] {entry.ProcessName} → hwnd {bestHwnd} (titleMatched={titleMatched})");
         }
+    }
+
+    /// <summary>
+    /// Compares two URLs by host only, so a window still matches its entry after the user has
+    /// navigated to another page on the same site.
+    /// </summary>
+    private static bool SameSite(string a, string b)
+    {
+        if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b)) return false;
+        if (string.Equals(a, b, StringComparison.OrdinalIgnoreCase)) return true;
+
+        if (Uri.TryCreate(a, UriKind.Absolute, out var ua) &&
+            Uri.TryCreate(b, UriKind.Absolute, out var ub))
+            return string.Equals(ua.Host, ub.Host, StringComparison.OrdinalIgnoreCase);
+
+        return false;
     }
 
     /// <summary>
@@ -1180,6 +1325,20 @@ public class WorkspaceService
                     UseShellExecute = false,
                 };
             }
+        }
+
+        // ── Dedicated browser window ──────────────────────────────────────
+        // --new-window forces a separate window instead of a tab in an existing one, which is
+        // what makes this coexist with the user's regular multi-tab browser window.
+        if (entry.IsDedicatedBrowserWindow && !string.IsNullOrEmpty(entry.BrowserUrl))
+        {
+            AppLogger.Info($"[BrowserUrl] launching {entry.ProcessName} --new-window {entry.BrowserUrl}");
+            return new ProcessStartInfo
+            {
+                FileName        = entry.ExecutablePath,
+                Arguments       = $"--new-window \"{entry.BrowserUrl}\"",
+                UseShellExecute = false,
+            };
         }
 
         // ── Store / MSIX app (TradingView, Notepad, Store-installed apps) ─

--- a/src/WindowAnchor/Services/WorkspaceService.cs
+++ b/src/WindowAnchor/Services/WorkspaceService.cs
@@ -812,7 +812,11 @@ public class WorkspaceService
                     var psi = BuildProcessStartInfo(entry);
                     Process.Start(psi);
                     anyLaunched = true;
-                    AppLogger.Info($"Launched: {entry.ExecutablePath}");
+                    // Log what actually launched: shell:AppsFolder for Store apps prints the
+                    // FileName+Arguments, everything else the executable path.
+                    string how = IsStoreApp(entry) ? $"{psi.FileName} {psi.Arguments}".Trim()
+                                                   : entry.ExecutablePath;
+                    AppLogger.Info($"Launched: {how}");
                 }
                 catch (Exception ex)
                 {
@@ -935,6 +939,47 @@ public class WorkspaceService
                 }
             }
 
+            // ── Tier 0.5: disambiguate multiple identical windows by title similarity ──
+            // Two windows of the same app (e.g. two TradingView charts, two Explorer windows)
+            // share the same exe, window class and — for packaged apps — the same AUMID, so the
+            // tiers below cannot tell them apart and may swap their positions. When more than one
+            // live window matches this entry's exe, pick the one whose current title is most
+            // similar to the saved title. TradingView puts the layout name at the end of the
+            // title ("… / 🦁LTF Luis" vs "… / 👀Outlook"), which is exactly what disambiguates
+            // them even though the price prefix keeps changing.
+            if (bestHwnd == IntPtr.Zero)
+            {
+                var sameExe = liveWindows
+                    .Where(kv => !consumedHwnds.Contains(kv.Key))
+                    .Where(kv => IdentityCompatible(entry, kv.Value.Record))
+                    .Where(kv => kv.Value.Record.ExecutablePath.Equals(
+                        entry.ExecutablePath, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                if (sameExe.Count > 1)
+                {
+                    IntPtr bestByTitle = IntPtr.Zero;
+                    double bestScore   = -1;
+                    foreach (var kv in sameExe)
+                    {
+                        double score = TitleSimilarity(entry.Position.TitleSnippet,
+                                                       kv.Value.Record.TitleSnippet);
+                        if (score > bestScore)
+                        {
+                            bestScore   = score;
+                            bestByTitle = kv.Key;
+                        }
+                    }
+
+                    if (bestByTitle != IntPtr.Zero)
+                    {
+                        bestHwnd = bestByTitle;
+                        AppLogger.Info($"Disambiguated {entry.ProcessName} by title similarity " +
+                                       $"(score={bestScore:F2}) → hwnd {bestByTitle}");
+                    }
+                }
+            }
+
             // ── Tier 1: exe + class ───────────────────────────────────────────────
             if (bestHwnd == IntPtr.Zero)
             {
@@ -981,6 +1026,41 @@ public class WorkspaceService
             _windowService.RestoreSingleWindow(bestHwnd, entry.Position);
             AppLogger.Info($"Restored entry[{i}] {entry.ProcessName} → hwnd {bestHwnd} (titleMatched={titleMatched})");
         }
+    }
+
+    /// <summary>
+    /// Sørensen–Dice similarity (0..1) between two window titles, computed over character
+    /// bigrams. Used to tell apart two windows of the same application whose only distinguishing
+    /// feature is part of the title (e.g. a TradingView layout name). Volatile shared content
+    /// such as a live price contributes equally to every candidate, so the distinctive part of
+    /// the title dominates the ranking.
+    /// </summary>
+    private static double TitleSimilarity(string a, string b)
+    {
+        a = (a ?? "").ToLowerInvariant();
+        b = (b ?? "").ToLowerInvariant();
+        if (a.Length < 2 || b.Length < 2)
+            return string.Equals(a, b, StringComparison.Ordinal) ? 1.0 : 0.0;
+
+        var bigrams = new Dictionary<string, int>();
+        for (int i = 0; i < a.Length - 1; i++)
+        {
+            string g = a.Substring(i, 2);
+            bigrams[g] = bigrams.TryGetValue(g, out int c) ? c + 1 : 1;
+        }
+
+        int overlap = 0;
+        for (int i = 0; i < b.Length - 1; i++)
+        {
+            string g = b.Substring(i, 2);
+            if (bigrams.TryGetValue(g, out int c) && c > 0)
+            {
+                bigrams[g] = c - 1;
+                overlap++;
+            }
+        }
+
+        return 2.0 * overlap / ((a.Length - 1) + (b.Length - 1));
     }
 
     /// <summary>

--- a/src/WindowAnchor/Services/WorkspaceService.cs
+++ b/src/WindowAnchor/Services/WorkspaceService.cs
@@ -31,17 +31,20 @@ public class WorkspaceService
     private readonly WindowService    _windowService;
     private readonly MonitorService   _monitorService;
     private readonly JumpListService  _jumpListService;
+    private readonly WebAppService    _webAppService;
 
     public WorkspaceService(
         StorageService  storageService,
         WindowService   windowService,
         MonitorService  monitorService,
-        JumpListService jumpListService)
+        JumpListService jumpListService,
+        WebAppService?  webAppService = null)
     {
         _storageService  = storageService;
         _windowService   = windowService;
         _monitorService  = monitorService;
         _jumpListService = jumpListService;
+        _webAppService   = webAppService ?? new WebAppService();
     }
 
     // ── Storage proxies ────────────────────────────────────────────
@@ -210,6 +213,16 @@ public class WorkspaceService
                 continue;
             }
 
+            // ── Browser web app (PWA) special case ─────────────────────────
+            // Installed web apps (Insilico Terminal, aggr.trade, …) run inside chrome.exe /
+            // brave.exe. Record how to relaunch the app itself instead of the browser.
+            var webAppEntry = TryBuildWebAppEntry(w);
+            if (webAppEntry != null)
+            {
+                entries.Add(webAppEntry);
+                continue;
+            }
+
             // ── Explorer special case ──────────────────────────────────────
             if (w.ProcessName.Equals("explorer", StringComparison.OrdinalIgnoreCase) &&
                 !string.IsNullOrEmpty(w.FolderPath))
@@ -219,6 +232,7 @@ public class WorkspaceService
                     ExecutablePath  = w.ExecutablePath,
                     ProcessName     = w.ProcessName,
                     WindowClassName = w.ClassName,
+                    AppUserModelId  = w.AppUserModelId,
                     FilePath        = saveFiles ? w.FolderPath : null,
                     FileConfidence  = saveFiles ? 95 : 0,
                     FileSource      = saveFiles ? "EXPLORER_FOLDER" : "NONE",
@@ -380,6 +394,7 @@ public class WorkspaceService
                 ExecutablePath  = w.ExecutablePath,
                 ProcessName     = w.ProcessName,
                 WindowClassName = w.ClassName,
+                AppUserModelId  = w.AppUserModelId,
                 FilePath        = filePath,
                 FileConfidence  = confidence,
                 FileSource      = source,
@@ -414,6 +429,82 @@ public class WorkspaceService
         return snapshot;
     }
 
+    // ── Browser web apps (PWAs) ───────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a <see cref="WorkspaceEntry"/> for an installed browser web app (PWA), or returns
+    /// <c>null</c> when <paramref name="w"/> is not a web-app window.
+    /// <para>
+    /// A window qualifies when it belongs to a Chromium-based browser <em>and</em> carries an
+    /// explicit <c>AppUserModelID</c> that either matches a Start-Menu shortcut created by the
+    /// browser (<c>--app-id=…</c>) or has the shape of a Chromium web-app AUMID. Ordinary browser
+    /// windows share the browser's own AUMID and are left to the normal code path.
+    /// </para>
+    /// </summary>
+    private WorkspaceEntry? TryBuildWebAppEntry(WindowRecord w)
+    {
+        if (!WebAppService.IsChromiumBrowser(w.ProcessName)) return null;
+        if (string.IsNullOrEmpty(w.AppUserModelId))          return null;
+
+        var info = _webAppService.FindByAumid(w.AppUserModelId);
+
+        if (info == null && !WebAppService.LooksLikeWebAppAumid(w.AppUserModelId))
+            return null;   // plain browser window
+
+        string? shortcutPath;
+        string? target;
+        string? args;
+        string  name;
+        string  source;
+
+        if (info != null)
+        {
+            shortcutPath = info.ShortcutPath;
+            target       = info.TargetPath;
+            args         = info.Arguments;
+            name         = info.DisplayName;
+            source       = "WEB_APP_SHORTCUT";
+        }
+        else
+        {
+            // No shortcut on disk (app installed without one, or shortcut deleted).
+            // Rebuild a command line from the AUMID: chrome.exe --app-id=<32-char id>.
+            string? appId = WebAppService.ExtractAppIdFromAumid(w.AppUserModelId);
+            if (appId == null) return null;
+
+            shortcutPath = null;
+            target       = w.ExecutablePath;
+            args         = $"--app-id={appId}";
+            name         = w.TitleSnippet;
+            source       = "WEB_APP_AUMID";
+            AppLogger.Warn($"[WebApp] no shortcut found for AUMID '{w.AppUserModelId}' — " +
+                           $"falling back to \"{target}\" {args}");
+        }
+
+        AppLogger.Info($"[WebApp] '{name}' detected (AUMID={w.AppUserModelId}, source={source})");
+
+        return new WorkspaceEntry
+        {
+            ExecutablePath        = w.ExecutablePath,
+            ProcessName           = w.ProcessName,
+            WindowClassName       = w.ClassName,
+            FilePath              = null,
+            FileConfidence        = 0,
+            FileSource            = source,
+            LaunchArg             = null,          // must stay null: not a document entry
+            AppUserModelId        = w.AppUserModelId,
+            IsWebApp              = true,
+            WebAppName            = name,
+            WebAppShortcutPath    = shortcutPath,
+            WebAppLaunchTarget    = target,
+            WebAppLaunchArguments = args,
+            Position              = w,
+            MonitorId             = w.MonitorId,
+            MonitorIndex          = w.MonitorIndex,
+            MonitorName           = w.MonitorName,
+        };
+    }
+
     // ── Per-window entry builder (shared by both snapshot paths) ──────────
 
     /// <summary>
@@ -423,6 +514,11 @@ public class WorkspaceService
     /// </summary>
     private WorkspaceEntry BuildEntryForWindow(WindowRecord w, bool saveFiles)
     {
+        // Browser web app (PWA) special case — must run before file detection, otherwise a
+        // web-app window is treated as a generic browser window.
+        var webAppEntry = TryBuildWebAppEntry(w);
+        if (webAppEntry != null) return webAppEntry;
+
         // Explorer special case
         if (w.ProcessName.Equals("explorer", StringComparison.OrdinalIgnoreCase) &&
             !string.IsNullOrEmpty(w.FolderPath))
@@ -432,6 +528,7 @@ public class WorkspaceService
                 ExecutablePath  = w.ExecutablePath,
                 ProcessName     = w.ProcessName,
                 WindowClassName = w.ClassName,
+                AppUserModelId  = w.AppUserModelId,
                 FilePath        = saveFiles ? w.FolderPath : null,
                 FileConfidence  = saveFiles ? 95 : 0,
                 FileSource      = saveFiles ? "EXPLORER_FOLDER" : "NONE",
@@ -546,6 +643,7 @@ public class WorkspaceService
             ExecutablePath  = w.ExecutablePath,
             ProcessName     = w.ProcessName,
             WindowClassName = w.ClassName,
+            AppUserModelId  = w.AppUserModelId,
             FilePath        = filePath,
             FileConfidence  = confidence,
             FileSource      = source,
@@ -624,7 +722,10 @@ public class WorkspaceService
         // the bare instance's slot while leaving zero windows for Praktikumsbericht/etc.
         // Skipping the bare launch lets the document entry start the exe properly.
         bool anyLaunched = false;
+        // Web-app windows must not count as "the browser is already running": a Chrome window
+        // that is really the Insilico Terminal PWA should not suppress launching Chrome itself.
         var runningExes = liveWindows.Values
+            .Where(v => !IsWebAppWindow(v.Record))
             .Select(v => v.Record.ExecutablePath.ToLowerInvariant())
             .ToHashSet();
 
@@ -641,6 +742,28 @@ public class WorkspaceService
             if (ct.IsCancellationRequested) return;
 
             var entry = snapshot.Entries[i];
+
+            // ── Installed browser web app (PWA) ───────────────────────────
+            // Always relaunch via its own shortcut / --app-id command line unless Phase 1
+            // already matched a live window with the same AppUserModelID. Never fall through
+            // to the generic browser launch, which would just open a normal browser window.
+            if (entry.IsWebApp)
+            {
+                if (restoredEntries.Contains(i)) continue;
+
+                try
+                {
+                    Process.Start(BuildProcessStartInfo(entry));
+                    anyLaunched = true;
+                    AppLogger.Info($"Launched web app: {entry.WebAppName} ({entry.AppUserModelId})");
+                }
+                catch (Exception ex)
+                {
+                    AppLogger.Warn($"Failed to launch web app '{entry.WebAppName}': {ex.Message}");
+                }
+                continue;
+            }
+
             if (string.IsNullOrEmpty(entry.ExecutablePath)) continue;
 
             if (!string.IsNullOrEmpty(entry.LaunchArg))
@@ -742,6 +865,20 @@ public class WorkspaceService
         // Build a consumed-hwnd set so each window only gets one entry applied.
         var consumedHwnds = new HashSet<IntPtr>();
 
+        // Guard against cross-matching browser windows.
+        // A PWA window (Insilico Terminal, aggr.trade, …) and a plain Chrome/Brave window share
+        // the same executable and window class, so every matching tier below would happily pair
+        // them up. Whenever either side is a web app, the AppUserModelIDs must be identical.
+        // Entries from older snapshots carry no AUMID and simply never claim a web-app window.
+        static bool IdentityCompatible(WorkspaceEntry e, WindowRecord rec)
+        {
+            string liveAumid = rec.AppUserModelId ?? "";
+            if (!e.IsWebApp && !WebAppService.LooksLikeWebAppAumid(liveAumid))
+                return true;   // both sides are ordinary windows — old behaviour
+
+            return string.Equals(e.AppUserModelId ?? "", liveAumid, StringComparison.OrdinalIgnoreCase);
+        }
+
         for (int i = 0; i < entries.Count; i++)
         {
             if (restoredEntries.Contains(i)) continue;
@@ -751,6 +888,24 @@ public class WorkspaceService
 
             IntPtr bestHwnd = IntPtr.Zero;
             bool titleMatched = false;
+
+            // ── Tier -1: web app match by AppUserModelID ──────────────────────────
+            // A PWA's title changes with the page it shows, so the AUMID is the only stable
+            // identifier. It is also unique per installed app, making this an exact match.
+            if (entry.IsWebApp && !string.IsNullOrEmpty(entry.AppUserModelId))
+            {
+                foreach (var (hwnd, (_, rec)) in liveWindows)
+                {
+                    if (consumedHwnds.Contains(hwnd)) continue;
+                    if (string.Equals(rec.AppUserModelId, entry.AppUserModelId,
+                                      StringComparison.OrdinalIgnoreCase))
+                    {
+                        bestHwnd = hwnd;
+                        titleMatched = true;   // right app is on screen — no relaunch needed
+                        break;
+                    }
+                }
+            }
 
             // ── Tier 0: document-aware match (exe + title contains document name) ──
             // This is the highest-priority match for document entries: we want
@@ -763,6 +918,7 @@ public class WorkspaceService
                 foreach (var (hwnd, (_, rec)) in liveWindows)
                 {
                     if (consumedHwnds.Contains(hwnd)) continue;
+                    if (!IdentityCompatible(entry, rec)) continue;
                     if (rec.ExecutablePath.Equals(entry.ExecutablePath, StringComparison.OrdinalIgnoreCase) &&
                         rec.TitleSnippet.ToLowerInvariant().Contains(expectedName))
                     {
@@ -779,6 +935,7 @@ public class WorkspaceService
                 foreach (var (hwnd, (_, rec)) in liveWindows)
                 {
                     if (consumedHwnds.Contains(hwnd)) continue;
+                    if (!IdentityCompatible(entry, rec)) continue;
                     if (rec.ExecutablePath.Equals(entry.ExecutablePath, StringComparison.OrdinalIgnoreCase) &&
                         rec.ClassName == entry.WindowClassName)
                     {
@@ -798,6 +955,7 @@ public class WorkspaceService
                 foreach (var (hwnd, (_, rec)) in liveWindows)
                 {
                     if (consumedHwnds.Contains(hwnd)) continue;
+                    if (!IdentityCompatible(entry, rec)) continue;
                     if (rec.ExecutablePath.Equals(entry.ExecutablePath, StringComparison.OrdinalIgnoreCase) &&
                         rec.TitleSnippet.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                     {
@@ -901,6 +1059,61 @@ public class WorkspaceService
     /// </summary>
     public ProcessStartInfo BuildProcessStartInfo(WorkspaceEntry entry)
     {
+        // ── Installed browser web app (PWA) ───────────────────────────────
+        // Launching the shortcut reproduces exactly what happens when the user starts the app
+        // from the Start Menu, including profile directory and app id.
+        if (entry.IsWebApp)
+        {
+            string? shortcut = entry.WebAppShortcutPath;
+
+            // Shortcut may have been moved or the app reinstalled — re-resolve by AUMID.
+            if ((string.IsNullOrEmpty(shortcut) || !File.Exists(shortcut)) &&
+                !string.IsNullOrEmpty(entry.AppUserModelId))
+            {
+                shortcut = _webAppService.FindByAumid(entry.AppUserModelId)?.ShortcutPath;
+            }
+
+            if (!string.IsNullOrEmpty(shortcut) && File.Exists(shortcut))
+            {
+                return new ProcessStartInfo
+                {
+                    FileName        = shortcut,
+                    UseShellExecute = true,
+                };
+            }
+
+            string target = entry.WebAppLaunchTarget ?? entry.ExecutablePath;
+            if (!string.IsNullOrEmpty(target))
+            {
+                AppLogger.Info($"[WebApp] launching '{entry.WebAppName}' via command line: " +
+                               $"{target} {entry.WebAppLaunchArguments}");
+                return new ProcessStartInfo
+                {
+                    FileName        = target,
+                    Arguments       = entry.WebAppLaunchArguments ?? "",
+                    UseShellExecute = false,
+                };
+            }
+        }
+
+        // ── Store / MSIX app (TradingView, Notepad, Store-installed apps) ─
+        // Their executables live under C:\Program Files\WindowsApps and must NOT be started
+        // by path: the process then runs without package identity, so the app cannot reach its
+        // packaged AppData container and comes back with default settings (e.g. light theme
+        // instead of dark). Launching through shell:AppsFolder\<AUMID> activates the package
+        // properly, exactly like clicking the Start-Menu tile.
+        // Entries that open a document keep the file association path below.
+        if (string.IsNullOrEmpty(entry.LaunchArg) && IsStoreApp(entry))
+        {
+            AppLogger.Info($"[StoreApp] launching {entry.ProcessName} via shell:AppsFolder\\{entry.AppUserModelId}");
+            return new ProcessStartInfo
+            {
+                FileName        = "explorer.exe",
+                Arguments       = $"shell:AppsFolder\\{entry.AppUserModelId}",
+                UseShellExecute = true,
+            };
+        }
+
         // VS Code special case: open as folder via CLI
         if (entry.ProcessName.Equals("Code", StringComparison.OrdinalIgnoreCase) &&
             !string.IsNullOrEmpty(entry.LaunchArg))
@@ -947,6 +1160,26 @@ public class WorkspaceService
     }
 
     // ── Browser detection helpers ─────────────────────────────────────────
+
+    /// <summary>
+    /// True when the entry belongs to a packaged (MSIX/Store) app that must be started through
+    /// its AppUserModelID rather than by executable path. Requires both a packaged install
+    /// location and an explicit AUMID (packaged AUMIDs have the form
+    /// <c>PackageFamilyName!AppId</c>).
+    /// </summary>
+    private static bool IsStoreApp(WorkspaceEntry entry) =>
+        !string.IsNullOrEmpty(entry.AppUserModelId) &&
+        entry.AppUserModelId.Contains('!') &&
+        entry.ExecutablePath.Contains(@"\WindowsApps\", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True when a live window is an installed browser web app rather than a normal
+    /// browser window, judged by the shape of its <c>AppUserModelID</c>.
+    /// </summary>
+    private static bool IsWebAppWindow(WindowRecord rec) =>
+        WebAppService.IsChromiumBrowser(rec.ProcessName) &&
+        WebAppService.LooksLikeWebAppAumid(rec.AppUserModelId);
+
 
     private static readonly HashSet<string> BrowserProcessNames = new(StringComparer.OrdinalIgnoreCase)
     {

--- a/src/WindowAnchor/Services/WorkspaceService.cs
+++ b/src/WindowAnchor/Services/WorkspaceService.cs
@@ -92,6 +92,12 @@ public class WorkspaceService
             .Where(w => !w.ProcessName.Equals("WindowAnchor", StringComparison.OrdinalIgnoreCase))
             .ToList();
 
+        // Resolve a friendly display name so the dialog shows "Insilico Terminal" rather than
+        // "brave" for installed web apps. Everything else keeps its process name.
+        foreach (var w in windows)
+            w.DisplayName = _webAppService.ResolveWebAppName(w.ProcessName, w.AppUserModelId)
+                            ?? w.ProcessName;
+
         return monitors
             .Select(m => (m, windows.Where(w => w.MonitorId == m.MonitorId).ToList()))
             .ToList();

--- a/src/WindowAnchor/UI/SaveWorkspaceDialog.xaml.cs
+++ b/src/WindowAnchor/UI/SaveWorkspaceDialog.xaml.cs
@@ -99,7 +99,7 @@ public partial class SaveWorkspaceDialog : FluentWindow
                 Windows = windows.Select(w => new WindowCheckItem
                 {
                     Record       = w,
-                    DisplayName  = w.ProcessName,
+                    DisplayName  = string.IsNullOrEmpty(w.DisplayName) ? w.ProcessName : w.DisplayName,
                     TitleSnippet = w.TitleSnippet,
                     IsSelected   = !ShouldAutoExclude(w),
                 }).ToList(),

--- a/src/WindowAnchor/UI/SettingsWindow.xaml
+++ b/src/WindowAnchor/UI/SettingsWindow.xaml
@@ -427,6 +427,33 @@
                     </Grid>
                 </Border>
 
+                <!-- Bulk selection bar (visible only while rows are checked) -->
+                <Border x:Name="BulkActionBar"
+                        Visibility="Collapsed"
+                        Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1" CornerRadius="8"
+                        Padding="16,10" Margin="0,0,0,8">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="BulkSelectionText"
+                                   VerticalAlignment="Center"
+                                   FontSize="13" FontWeight="Medium"
+                                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <ui:Button Grid.Column="1" Content="Clear selection"
+                                   Appearance="Secondary" Margin="0,0,8,0"
+                                   Click="OnClearWorkspaceSelection"/>
+                        <ui:Button Grid.Column="2" Content="Delete selected"
+                                   Appearance="Danger"
+                                   Icon="{ui:SymbolIcon Delete24}"
+                                   Click="OnDeleteSelectedWorkspaces"/>
+                    </Grid>
+                </Border>
+
                 <!-- Workspace rows card -->
                 <Border x:Name="WorkspacesCard"
                         Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
@@ -437,6 +464,7 @@
                         <!-- Column headers -->
                         <Grid Margin="12,10,12,4">
                             <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="32"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="120"/>
                                 <ColumnDefinition Width="68"/>
@@ -444,19 +472,24 @@
                                 <ColumnDefinition Width="48"/>
                                 <ColumnDefinition Width="36"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="Name"
+                            <CheckBox x:Name="SelectAllWorkspaces" Grid.Column="0"
+                                      VerticalAlignment="Center" Margin="0,0,0,2"
+                                      ToolTip="Select all workspaces"
+                                      Checked="OnSelectAllWorkspacesChanged"
+                                      Unchecked="OnSelectAllWorkspacesChanged"/>
+                            <TextBlock Grid.Column="1" Text="Name"
                                        FontSize="11" FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                            <TextBlock Grid.Column="1" Text="Saved"
+                            <TextBlock Grid.Column="2" Text="Saved"
                                        FontSize="11" FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                            <TextBlock Grid.Column="2" Text="Monitors"
+                            <TextBlock Grid.Column="3" Text="Monitors"
                                        FontSize="11" FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                            <TextBlock Grid.Column="3" Text="Windows"
+                            <TextBlock Grid.Column="4" Text="Windows"
                                        FontSize="11" FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                            <TextBlock Grid.Column="4" Text="Files"
+                            <TextBlock Grid.Column="5" Text="Files"
                                        FontSize="11" FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                         </Grid>
@@ -469,6 +502,7 @@
                                     <Border Style="{StaticResource RowCardStyle}" Margin="4,1">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="32"/>
                                                 <ColumnDefinition Width="*"/>
                                                 <ColumnDefinition Width="120"/>
                                                 <ColumnDefinition Width="68"/>
@@ -477,8 +511,15 @@
                                                 <ColumnDefinition Width="36"/>
                                             </Grid.ColumnDefinitions>
 
-                                            <!-- Col 0: view mode name + fingerprint subtitle -->
-                                            <StackPanel Grid.Column="0"
+                                            <!-- Col 0: bulk-selection checkbox -->
+                                            <CheckBox Grid.Column="0"
+                                                      VerticalAlignment="Center"
+                                                      IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                                      Checked="OnWorkspaceSelectionChanged"
+                                                      Unchecked="OnWorkspaceSelectionChanged"/>
+
+                                            <!-- Col 1: view mode name + fingerprint subtitle -->
+                                            <StackPanel Grid.Column="1"
                                                         Style="{StaticResource HideWhenEditing}"
                                                         VerticalAlignment="Center">
                                                 <StackPanel Orientation="Horizontal">
@@ -505,8 +546,8 @@
                                                            Margin="0,1,0,0"/>
                                             </StackPanel>
 
-                                            <!-- Col 0: edit mode — TextBox + check/X icons -->
-                                            <StackPanel Grid.Column="0"
+                                            <!-- Col 1: edit mode — TextBox + check/X icons -->
+                                            <StackPanel Grid.Column="1"
                                                         Style="{StaticResource ShowWhenEditing}"
                                                         Orientation="Horizontal"
                                                         VerticalAlignment="Center">
@@ -537,29 +578,29 @@
                                                 </Button>
                                             </StackPanel>
 
-                                            <!-- Cols 1-4: hidden in edit mode -->
-                                            <TextBlock Grid.Column="1"
+                                            <!-- Cols 2-5: hidden in edit mode -->
+                                            <TextBlock Grid.Column="2"
                                                        Style="{StaticResource HideWhenEditing}"
                                                        Text="{Binding SavedAtDisplay}"
                                                        FontSize="12"
                                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                                        VerticalAlignment="Center"/>
 
-                                            <TextBlock Grid.Column="2"
+                                            <TextBlock Grid.Column="3"
                                                        Style="{StaticResource HideWhenEditing}"
                                                        Text="{Binding MonitorCountLabel}"
                                                        FontSize="12"
                                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                                        VerticalAlignment="Center"/>
 
-                                            <TextBlock Grid.Column="3"
+                                            <TextBlock Grid.Column="4"
                                                        Style="{StaticResource HideWhenEditing}"
                                                        Text="{Binding EntryCount}"
                                                        FontSize="12"
                                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                                        VerticalAlignment="Center"/>
 
-                                            <TextBlock Grid.Column="4"
+                                            <TextBlock Grid.Column="5"
                                                        Style="{StaticResource HideWhenEditing}"
                                                        Text="{Binding SavedWithFilesLabel}"
                                                        FontSize="12"
@@ -567,7 +608,7 @@
                                                        VerticalAlignment="Center"/>
 
                                             <!-- More (⋯) button -->
-                                            <Button Grid.Column="5"
+                                            <Button Grid.Column="6"
                                                     Style="{StaticResource MoreBtnStyle}"
                                                     Tag="{Binding}"
                                                     Click="OnWorkspaceMoreClick">

--- a/src/WindowAnchor/UI/SettingsWindow.xaml.cs
+++ b/src/WindowAnchor/UI/SettingsWindow.xaml.cs
@@ -35,6 +35,10 @@ public partial class SettingsWindow : FluentWindow
         public string MonitorCountLabel    => Source.Monitors.Count > 0 ? $"{Source.Monitors.Count}" : "—";
         public string SavedWithFilesLabel  => Source.SavedWithFiles ? "Yes" : "—";
 
+        /// <summary>Checkbox state for bulk actions (delete several workspaces at once).</summary>
+        private bool _isSelected;
+        public bool IsSelected { get => _isSelected; set { _isSelected = value; OnPropertyChanged(); } }
+
         private bool   _isEditing;
         private string _editName = "";
         public bool   IsEditing { get => _isEditing; set { _isEditing = value; OnPropertyChanged(); } }
@@ -531,6 +535,90 @@ public partial class SettingsWindow : FluentWindow
         WorkspacesList.ItemsSource = wsRows;
         WorkspaceCountText.Text    = $"{wsRows.Count} workspace{(wsRows.Count == 1 ? "" : "s")} saved";
         WorkspacesEmpty.Visibility = wsRows.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+
+        // Rows are rebuilt from scratch, so any previous selection no longer refers to them.
+        SelectAllWorkspaces.IsChecked = false;
+        UpdateBulkActionBar();
+    }
+
+    // ── Bulk selection ───────────────────────────────────────────────────────
+
+    /// <summary>Rows currently ticked for a bulk action.</summary>
+    private List<WorkspaceRow> SelectedWorkspaceRows =>
+        (WorkspacesList.ItemsSource as IEnumerable<WorkspaceRow>)?
+            .Where(r => r.IsSelected).ToList() ?? new List<WorkspaceRow>();
+
+    /// <summary>
+    /// Shows or hides the bulk action bar and updates its counter. Called whenever a row
+    /// checkbox changes and after the list is rebuilt.
+    /// </summary>
+    private void UpdateBulkActionBar()
+    {
+        int count = SelectedWorkspaceRows.Count;
+        BulkActionBar.Visibility = count == 0 ? Visibility.Collapsed : Visibility.Visible;
+        BulkSelectionText.Text   = $"{count} workspace{(count == 1 ? "" : "s")} selected";
+    }
+
+    private void OnWorkspaceSelectionChanged(object sender, RoutedEventArgs e) => UpdateBulkActionBar();
+
+    /// <summary>Header checkbox: ticks or unticks every row at once.</summary>
+    private void OnSelectAllWorkspacesChanged(object sender, RoutedEventArgs e)
+    {
+        if (WorkspacesList.ItemsSource is not IEnumerable<WorkspaceRow> rows) return;
+
+        bool select = SelectAllWorkspaces.IsChecked == true;
+        foreach (var row in rows) row.IsSelected = select;
+
+        UpdateBulkActionBar();
+    }
+
+    private void OnClearWorkspaceSelection(object sender, RoutedEventArgs e)
+    {
+        SelectAllWorkspaces.IsChecked = false;   // also clears every row via the handler above
+        if (WorkspacesList.ItemsSource is IEnumerable<WorkspaceRow> rows)
+            foreach (var row in rows) row.IsSelected = false;
+
+        UpdateBulkActionBar();
+    }
+
+    /// <summary>
+    /// Deletes every ticked workspace after a single confirmation listing the names.
+    /// </summary>
+    private void OnDeleteSelectedWorkspaces(object sender, RoutedEventArgs e)
+    {
+        var selected = SelectedWorkspaceRows;
+        if (selected.Count == 0) return;
+
+        // Show at most five names so the dialog stays readable with a large selection.
+        var shown = selected.Take(5).Select(r => $"\u2022 {r.Name}");
+        string list = string.Join(Environment.NewLine, shown);
+        if (selected.Count > 5)
+            list += $"{Environment.NewLine}\u2022 \u2026and {selected.Count - 5} more";
+
+        var confirm = System.Windows.MessageBox.Show(
+            $"Delete {selected.Count} workspace{(selected.Count == 1 ? "" : "s")}?" +
+            $"{Environment.NewLine}{Environment.NewLine}{list}" +
+            $"{Environment.NewLine}{Environment.NewLine}This cannot be undone.",
+            "Delete Workspaces",
+            System.Windows.MessageBoxButton.OKCancel,
+            System.Windows.MessageBoxImage.Warning);
+
+        if (confirm != System.Windows.MessageBoxResult.OK) return;
+
+        foreach (var row in selected)
+        {
+            try
+            {
+                _storageService.DeleteWorkspace(row.Source);
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Warn($"Failed to delete workspace '{row.Name}': {ex.Message}");
+            }
+        }
+
+        AppLogger.Info($"Deleted {selected.Count} workspace(s) via bulk selection");
+        Refresh();
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

Several kinds of window could not be identified correctly, because WindowAnchor identifies windows by executable path and window class only. That is not enough for windows that share an executable with something else.

**Browser web apps.** A web app installed from Chrome or Brave (e.g. Insilico Terminal) is not a separate process - it runs inside `chrome.exe` / `brave.exe` and uses the same window class (`Chrome_WidgetWin_1`) as an ordinary browser window. So a PWA window was saved as "a Chrome window", and on restore `BuildProcessStartInfo` took the browser branch and started `chrome.exe --restore-last-session`, producing a plain browser window instead of the app. The process command line does not help either: launching a PWA (`chrome_proxy.exe --app-id=...`) only creates a window inside the already-running browser process.

**Store apps.** Apps installed from the Microsoft Store live under `C:\Program Files\WindowsApps`. Starting their executable by path runs them without package identity, so they cannot reach their packaged settings container - TradingView reopened in light theme instead of the user's dark theme.

**Two windows of the same app.** Two TradingView charts (or two Explorer windows) share executable, window class and - for packaged apps - AppUserModelID, so restore could not tell them apart and sometimes placed each on the other's monitor.

**Single-site browser windows.** Sites without a PWA manifest cannot be installed as an app, but users still keep them in a dedicated window beside a normal multi-tab window. Such a window is indistinguishable from any other browser window, and `--restore-last-session` restores a session rather than a specific window.

## Approach

The `AppUserModelID` is the missing per-window identity. Chromium assigns every web-app window its own AUMID - that is how an installed web app gets its own taskbar group - and writes the same AUMID onto the Start-Menu shortcut it creates at install time. Packaged apps expose a `PackageFamilyName!AppId` AUMID via their process.

- **Capture** - `SHGetPropertyStoreForWindow` + `PKEY_AppUserModel_ID` per window, falling back to `GetApplicationUserModelId` on the process for packaged apps, whose windows usually carry no explicit AUMID.
- **Resolve** - `WebAppService` indexes `.lnk` files under the Start Menu and Desktop and keeps those carrying a Chromium app switch (`--app-id=` / `--app=`), so a window's AUMID maps back to the shortcut that launches it.
- **Restore** - web apps launch through their shortcut (with a `chrome.exe --app-id=<id>` fallback), Store apps through `shell:AppsFolder\<AUMID>`.
- **Match** - dedicated tiers match web apps by AUMID and single-site windows by URL host; `IdentityCompatible` stops a browser entry from claiming a PWA window, or the reverse. Where several windows of one app remain ambiguous, they are ranked by title similarity (Sorensen-Dice over character bigrams), which is robust against volatile parts of a title such as a live price.

Snapshots saved before this change carry no AUMID and keep the previous behaviour.

## Also included

- **"Align + minimize others" restore mode** - repositions a workspace's windows and minimizes everything else without closing anything; a non-destructive middle ground between Restore and Switch. Available per workspace from the tray menu.
- **Dedicated browser windows by URL** - opt-in via `dedicatedBrowserUrlPatterns` in `settings.json` (a bare domain matches the whole site). Matching windows have their address-bar URL read via UI Automation and are reopened with `--new-window <url>`. When no patterns are configured, no URLs are read and snapshots are unchanged.
- **Bulk delete for saved workspaces** - each row in Settings gets a checkbox plus a select-all box in the header; deleting a selection takes one confirmation instead of one per workspace.
- **Friendly names in the Save dialog** - installed web apps show as "Insilico Terminal" rather than "brave".
- **Case-insensitive settings parsing** - hand-edited keys apply instead of being silently ignored.

## Changes

| File | Change |
|---|---|
| `Native/NativeMethods.Shell.cs` | **new** - `IPropertyStore`, `PROPVARIANT`, `IShellLinkW`, `IPersistFile`, `GetApplicationUserModelId` |
| `Services/WebAppService.cs` | **new** - AUMID lookup (window + process), shortcut index, app-id heuristics |
| `Services/BrowserUrlService.cs` | **new** - address-bar URL via UI Automation, with timeout |
| `Models/WindowRecord.cs`, `Models/WorkspaceEntry.cs` | AUMID, web-app and dedicated-browser fields |
| `Models/AppSettings.cs` | `DedicatedBrowserUrlPatterns` |
| `Services/WindowService.cs` | capture AUMID and URL; `MinimizeUserWindowsExcept` |
| `Services/WorkspaceService.cs` | entry builders, launch paths, AUMID/URL/title matching |
| `Services/SettingsService.cs` | case-insensitive JSON property matching |
| `Services/LayoutCoordinator.cs`, `App.xaml.cs` | align mode, tray entry, service wiring |
| `UI/SettingsWindow.xaml(.cs)`, `UI/SaveWorkspaceDialog.xaml.cs` | bulk selection, display names |

Note on `CONTRIBUTING.md`: the new P/Invoke declarations went into a third file, `Native/NativeMethods.Shell.cs`, rather than the two listed there - the shell property system and `IShellLink` COM interfaces did not fit either the Window or Display file. Happy to merge them elsewhere if preferred.

No new NuGet dependencies (`System.Windows.Automation` ships with the Windows Desktop SDK).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Testing

Verified on Windows 11, two monitors, with a workspace containing two installed web apps (Insilico Terminal via Brave, aggr.trade via Chrome), two TradingView charts with different layouts, a single-site Brave window, ordinary Chrome and Brave windows, Store-installed Notepad, Explorer and Discord.

- Saving logs one line per special window, e.g. `[WebApp] 'Insilico Terminal' detected (AUMID=Brave._crx_..., source=WEB_APP_SHORTCUT)`; plain browser windows continue through the normal path.
- Restoring a closed workspace brings both web apps back as app windows, TradingView back with its own dark theme, and the single-site window back at its URL alongside the normal multi-tab window.
- Restoring with those windows already open repositions them instead of launching duplicates.
- Two TradingView charts return to their own monitors rather than swapping.
- Selecting several workspaces and deleting them removes exactly those, and the list refreshes with the selection cleared.

- [x] Tested on Windows 11
- [ ] Tested on Windows 10
- [x] Tested with multiple monitors
- [x] Tested workspace save/restore
- [x] Tested file detection

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Known limitations

- `dedicatedBrowserUrlPatterns` has no settings UI yet and must be added to `settings.json` by hand.
- Where no shortcut exists for a web app, the launch command is rebuilt as `--app-id=<id>` without `--profile-directory`, so it opens in the default profile. Logged as a warning.
- Disambiguating two windows of the same app relies on their titles differing; identical titles remain ambiguous.
